### PR TITLE
Create pico_w.sh

### DIFF
--- a/scripts/rp2/pico_w.sh
+++ b/scripts/rp2/pico_w.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#  This file is part of the micropython-builder project,
+#  https://github.com/v923z/micropython-builder
+#  The MIT License (MIT)
+#  Copyright (c) 2022 Zoltán Vörös
+#  16.2.2023, sakluk: Added new port for Pico W
+
+source ./scripts/rp2/rp2.sh
+
+build_rp2 "PICO_W"


### PR DESCRIPTION
Based on discussion on: https://github.com/v923z/micropython-builder/issues/5 I created a pull request for Raspberry Pi Pico W board. 

Not tested, but guess that only thing to modify compared to [pico.sh](https://github.com/v923z/micropython-builder/blob/master/scripts/rp2/pico.sh) is the port parameter: `build_rp2 "PICO"` => `build_rp2 "PICO_W"` 