### PR TITLE
Using latest MicroPython tag by default

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -22,7 +22,8 @@ git clone https://github.com/v923z/micropython-ulab ulab || git -C ulab pull
 
 # only check out micropython, if it is not available locally, otherwise, pull
 git clone https://github.com/micropython/micropython micropython || git -C micropython pull
-git -C micropython checkout v1.24.0
+: ${MICROPYTHON_TAG:=$(git tag --sort -v:refname | grep -v preview | head -n 1)}
+git -C micropython checkout ${MICROPYTHON_TAG}
 
 cd micropython
 git submodule update --init


### PR DESCRIPTION
* Will checkout the latest tag that is not a "preview" instead of a fixed version number.
* Can be overridden by setting MICROPYTHON_TAG env var.